### PR TITLE
Three commented out alternatives to the current double interval solution

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,5 @@
 var express = require('express'),
+    async = require('async'),
     twitter = require('./twitter'),
     instagram = require('./instagram');
 var router = express.Router();
@@ -8,6 +9,53 @@ var world_trends, ig_pics;
 router.get('/', function(req, res, next) {
     res.send(ig_pics);
 });
+
+var INTERVAL = 100000;
+
+/* A few alternate solutions: */
+
+/*
+ * (1) Using an Interval
+ */
+/*
+function feed_twitter_into_instagram_in_interval() {
+    async.waterfall([twitter.trends, instagram.pictures], function(err, pictures) {
+        if (err) return console.error(err);
+        ig_pics = pictures;
+    });
+}
+setInterval(feed_twitter_into_instagram_in_interval, INTERVAL); // Need to set the interval
+feed_twitter_into_instagram_in_interval();                      // Also, need to call it so it happens now
+*/
+
+/*
+ * (2) Using a timeout and some recursion
+ */
+/*
+function feed_twitter_into_instagram_and_set_timeout() {
+    // We want calling this function again to be independent of the results, so this is outside of the waterfall
+    setTimeout(feed_twitter_into_instagram_and_set_timeout, INTERVAL);
+    async.waterfall([twitter.trends, instagram.pictures], function(err, pictures) {
+        if (err) return console.error(err);
+        ig_pics = pictures;
+    });
+}
+feed_twitter_into_instagram_and_set_timeout(); // Just need to kick it off. It will deal with calling again
+*/
+
+/*
+ * (3) Using async.forever and a timeout
+ */
+/*
+async.forever(function(next) {
+    // We want calling this function again to be independent of the results, so this is outside of the waterfall
+    setTimeout(next, INTERVAL);
+    async.waterfall([twitter.trends, instagram.pictures], function(err, pictures) {
+        if (err) return console.error(err);
+        ig_pics = pictures;
+    });
+});
+*/
 
 twitter.trends(function(err, trends) {
     if (err) console.error(err);


### PR DESCRIPTION
The current solution has an issue. You want twitter.trends to always happen before instagram.pictures, but, after the intervals are set:
(1) twitter.trends kicks off at 100000, 200000, 300000, 400000, 500000, 600000, etc.
(2) instagram.pictures kicks off at 90000, 180000, 270000, 360000, 450000, 540000, etc.

Eventually, they swap which'll happen first. At one point they'll start simultaneously. Also, depending on how long each takes, these aren't really relevant. If twitter.trends takes a long time, it could kick off first, but not finish until after instagram.pictures is done. It's pretty undefined what happens when and why.

This change has three commented out solutions. They all do the same thing: Kick off twitter.trends every 100000, have instagram.pictures happen after it, and set the variable if all of that succeeds. I'd say they're all pretty equal in terms in which to pick. It's more about which fits your style better and which is more flexible to what features you might want to add later. I left them all commented out so you can pick which you like best.

TLDR; The double intervals doesn't act exactly how you want, here's three solutions that do.
